### PR TITLE
Add 13B and 4_0 model for metal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+

--- a/config.py
+++ b/config.py
@@ -15,10 +15,20 @@ models = {
         'type': 'local',
         'filename': 'mistral-7b-instruct-v0.1.Q5_K_M.gguf',
     },
-    'CodeLlama-34b': {
-        'url': 'https://huggingface.co/TheBloke/CodeLlama-34B-Instruct-GGUF/resolve/main/codellama-34b-instruct.Q4_K_M.gguf',
+    # 'CodeLlama-34b': {
+    #     'url': 'https://huggingface.co/TheBloke/CodeLlama-34B-Instruct-GGUF/resolve/main/codellama-34b-instruct.Q4_K_M.gguf',
+    #     'type': 'local',
+    #     'filename': 'codellama-34b-instruct.Q4_K_M.gguf',
+    # },
+    'CodeLlama-Instruct-13B': {
+        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGUF/raw/main/codellama-13b-instruct.Q5_K_M.gguf',
         'type': 'local',
-        'filename': 'codellama-34b-instruct.Q4_K_M.gguf',
+        'filename': 'codellama-13b-instruct.Q5_K_M.gguf',
+    },
+    'CodeLlama-Python-13B': {
+        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Python-GGUF/raw/main/codellama-13b-python.Q5_K_M.gguf',
+        'type': 'local',
+        'filename': 'codellama-13b-python.Q5_K_M.gguf',
     },
     'default': 'GitHub',
 }

--- a/config.py
+++ b/config.py
@@ -10,6 +10,11 @@ models = {
         'type': 'local',
         'filename': 'codellama-7b.Q5_K_S.gguf',
     },
+    'CodeLlama-7b-4_0_metal': {
+        'url': 'https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q4_0.gguf',
+        'type': 'local',
+        'filename': 'codellama-7b.Q4_0.gguf',
+    },
     'Mistral-7b': {
         'url': 'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q5_K_M.gguf',
         'type': 'local',

--- a/config.py
+++ b/config.py
@@ -21,12 +21,12 @@ models = {
     #     'filename': 'codellama-34b-instruct.Q4_K_M.gguf',
     # },
     'CodeLlama-Instruct-13B': {
-        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGUF/raw/main/codellama-13b-instruct.Q5_K_M.gguf',
+        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGUF/resolve/main/codellama-13b-instruct.Q5_K_M.gguf',
         'type': 'local',
         'filename': 'codellama-13b-instruct.Q5_K_M.gguf',
     },
     'CodeLlama-Python-13B': {
-        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Python-GGUF/raw/main/codellama-13b-python.Q5_K_M.gguf',
+        'url': 'https://huggingface.co/TheBloke/CodeLlama-13B-Python-GGUF/resolve/main/codellama-13b-python.Q5_K_M.gguf',
         'type': 'local',
         'filename': 'codellama-13b-python.Q5_K_M.gguf',
     },


### PR DESCRIPTION
use
```
pip uninstall llama-cpp-python -y
CMAKE_ARGS="-DLLAMA_METAL=on" pip install -U llama-cpp-python --no-cache-dir
pip install 'llama-cpp-python[server]'
```
to install metal version. only works on 4_0 quant models